### PR TITLE
Update Expo instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ allprojects {
 ```
 
 ### Using `expo`
-> :warning: This package cannot be used in "Expo Go" because [it requires custom native code](https://docs.expo.io/workflow/customizing/). However you can leverage this library with a [development build](https://docs.expo.dev/development/introduction/) or [prebuild](https://docs.expo.dev/workflow/prebuild/).  
+> :warning: This package [requires custom native code](https://docs.expo.io/workflow/customizing/) and can be used with [Development builds](https://docs.expo.dev/develop/development-builds/introduction/) or  [prebuild](https://docs.expo.dev/workflow/prebuild/) and cannot be used with Expo Go.
 
 1. Install the SDK:
 ```
-expo install @beyondidentity/bi-sdk-react-native
+npx expo install @beyondidentity/bi-sdk-react-native
 ```
 
 2. Add the SDK [config plugin](https://docs.expo.dev/guides/config-plugins/) to the [plugins array](https://docs.expo.dev/versions/latest/config/app/#plugins) of your app.{json,config.js,config.ts}:
@@ -87,20 +87,7 @@ expo install @beyondidentity/bi-sdk-react-native
 
 3. Set native requirments either with [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) or modify project [static files](https://docs.expo.dev/guides/config-plugins/#static-modification)
 
-A. Modify the following static files
-
-android/gradle.properties
-```
-android.minSdkVersion=26
-```
-ios/Podfile.properties.json
-```
-"ios.deploymentTarget": "13.0"
-```
-
-*or* 
-
-B. Add [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) to your app.{json,config.js,config.ts}:
+A. Add [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) to your app.{json,config.js,config.ts}:
 
 
 ```
@@ -128,7 +115,22 @@ expo install expo-build-properties
 }
 ```
 
-4.  Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.dev/workflow/customizing/) guide.
+*or*
+
+B. Modify the following static files
+
+android/gradle.properties
+```
+android.minSdkVersion=26
+```
+ios/Podfile.properties.json
+```
+"ios.deploymentTarget": "13.0"
+```
+
+
+
+4.  Next, rebuild your app as described in the ["Adding custom native code"]([https://docs.expo.dev/workflow/customizing/](https://docs.expo.dev/workflow/customizing/#generate-native-projects-with-prebuild)) guide.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ npx expo install @beyondidentity/bi-sdk-react-native
 }
 ```
 
-3. Set native requirments either with [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) or modify project [static files](https://docs.expo.dev/guides/config-plugins/#static-modification)
-
-A. Add [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) to your app.{json,config.js,config.ts}:
+3. Set native requirments either with [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/). Add [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) to your app.{json,config.js,config.ts}:
 
 
 ```
@@ -113,19 +111,6 @@ expo install expo-build-properties
     ]
   }
 }
-```
-
-*or*
-
-B. Modify the following static files
-
-android/gradle.properties
-```
-android.minSdkVersion=26
-```
-ios/Podfile.properties.json
-```
-"ios.deploymentTarget": "13.0"
 ```
 
 


### PR DESCRIPTION
Hi team 👋 

I recently got to peek @turnipdabeets's PR in Expo's docs (which is very well written set of instructions! Thank you, Anna! 🙏 ) and came across this repo.

I'm suggestion, through this PR, to update some of the Expo related instructions for the following reasons:
- Based on our community observation, most developers who want to use Expo, prefer development builds and prebuild (as the warning message already states). Thus, I though, the "warning" added in the Expo's section should lead with that msg instead of Expo Go.
- Using `npx expo install...` instead of `expo install`. Since the former referees to the new [Expo CLI](https://docs.expo.dev/more/expo-cli/) which doesn't require any global package installation. For `expo install` people will need to instal the deprecated global cli (and we are not recommending that).
- I also removed the manual instructions in step 3. Adding a config plugin should be sufficient to add those properties because when editing native files, if a developer decides to deploy their app using Expo ecosystem, the iOS and Android directories are not going to be uploaded on the service's cloud deployment. That can be really confusing to for someone who isnt' much experienced. Also, if a developer wants to prebuild, those instructions mentioned in **app.json** will modify those native files automatically when running `npx expo run:ios/android`.